### PR TITLE
Fix public logic of travis_env_var resource

### DIFF
--- a/travis/resource_env_var.go
+++ b/travis/resource_env_var.go
@@ -75,14 +75,10 @@ func resourceEnvVar() *schema.Resource {
 			switch {
 			case publicValue != "" && value == "": // public: true
 				d.SetNew("public", true)
-				d.SetNew("value", "")
-			case publicValue != "" && value == "": // public: false
+				d.Clear("value")
+			case value != "" && publicValue == "": // public: false
 				d.SetNew("public", false)
-				d.SetNew("value", "")
-			case publicValue == "" && value == "": // If both public_value and value are empty, public is true
-				d.SetNew("public", true)
-				d.SetNew("public_value", "")
-				d.ForceNew("value")
+				d.Clear("public_value")
 			}
 			return nil
 		},
@@ -168,10 +164,16 @@ func resourceEnvVarDelete(ctx context.Context, d *schema.ResourceData, m interfa
 
 func generateEnvVarBody(d *schema.ResourceData) *travis.EnvVarBody {
 	public := d.Get("public").(bool)
+
 	value := d.Get("value").(string)
 	if public {
 		value = d.Get("public_value").(string)
 	}
+
+	if value == "" {
+		public = true
+	}
+
 	return &travis.EnvVarBody{
 		Name:   d.Get("name").(string),
 		Value:  value,


### PR DESCRIPTION
## Why

If set computed value to `value` attribute, apply is fail.

```console
$ TF_ACC=true go test ./...
?   	github.com/bgpat/terraform-provider-travis	[no test files]
--- FAIL: TestAccResourceEnvVar_basic (5.84s)
    resource_env_var_test.go:22: Step 1/3 error: Error running apply: exit status 1
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for travis_env_var.bar to include new values learned
        so far during apply, provider "registry.terraform.io/hashicorp/travis"
        produced an invalid new value for .public: was known, but now unknown.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
FAIL
FAIL	github.com/bgpat/terraform-provider-travis/travis	15.134s
FAIL
```

## What

If both `value` and `public_value` attribute are empty, do not set `public` attribute.