### PR TITLE
Renovate label

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -1,0 +1,17 @@
+name: renovate-config-validator
+on:
+  pull_request:
+    paths:
+      - renovate.json
+      - renovate.json5
+      - .github/renovate.json
+      - .github/renovate.json5
+      - .renovaterc
+      - .renovaterc.json
+      - .renovaterc.json5
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.3

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,8 @@
         "golang.org/x/crypto"
       ],
       "matchUpdateTypes": ["digest"],
-      "automerge": true
+      "automerge": true,
+      "labels": ["dependencies"]
     }
   ]
 }


### PR DESCRIPTION
## Why

Pull requests created by renovate are grouped as `Changed` section in the release page.
e.g. https://github.com/bgpat/terraform-provider-travis/releases/tag/v1.5.3

## What

Add `dependencies` label to renovate pull requests.
And I add renovate-config-validator workflow.